### PR TITLE
chore: 회원가입 UI 수정 #5

### DIFF
--- a/src/components/RegisterForm/RegisterForm.tsx
+++ b/src/components/RegisterForm/RegisterForm.tsx
@@ -95,9 +95,9 @@ const RegisterForm = () => {
     >
       <div className='w-full h-1 bg-gray-200 my-8'>
         <div
-          className={`flex justify-center h-1 bg-green-600 transition-all ease ${Width[currentStep]}`}
+          className={`flex justify-end h-1 bg-green-600 transition-all ease ${Width[currentStep]}`}
         >
-          <p className='text-xs md:text-sm text-green-600 -mt-5'>
+          <p className='absolute text-xs md:text-sm text-green-600 -mt-5'>
             {RegisterStep[currentStep].key}
           </p>
         </div>

--- a/src/components/commons/inputs/NewPasswordInput.tsx
+++ b/src/components/commons/inputs/NewPasswordInput.tsx
@@ -57,12 +57,15 @@ const NewPasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
       state: [value, setValue],
     } = props;
     const { state: show, toggleState } = useToggle(false);
+    const [hasCapital, setHasCapital] = useState(false);
     const [hasNumber, setHasNumber] = useState(false);
     const [hasSpecial, setHasSpecial] = useState(false);
     const [moreThanTen, setMoreThanTen] = useState(false);
     useEffect(() => {
       const digitRegex = /\d/;
       const specialRegex = /[!@#$%^&*()\-=_+[\]{};':"\\|,.<>/?]/;
+      const capitalRegex = /(?=.*?[a-z])(?=.*?[A-Z])/;
+      setHasCapital(capitalRegex.test(value));
       setHasNumber(digitRegex.test(value));
       setHasSpecial(specialRegex.test(value));
       setMoreThanTen(value.length >= 10);
@@ -88,6 +91,11 @@ const NewPasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           />
         </div>
         <div className='flex space-x-3 mx-2'>
+          <p
+            className={`font-semibold text-xs ${hasCapital ? valid : invalid}`}
+          >
+            ✓ 대소문자
+          </p>
           <p className={`font-semibold text-xs ${hasNumber ? valid : invalid}`}>
             ✓ 숫자
           </p>


### PR DESCRIPTION
## 데모

![iPhone 12 Pro-1688430596162](https://github.com/28chungchun/front-end/assets/86599495/00f543d6-0a83-441c-a71e-45647472b024)

## 구현내용

- 회원가입 단계 안내 문구를 오른쪽에 배치했습니다.
- 회원가입 시 설정하는 비밀번호 규칙으로 대소문자 규칙을 추가했습니다.
- 작은 화면에서 안내 문구가 줄 바꿈 되는 문제를 해결 했습니다.

## 참고사항

[Apple 레이아웃 가이드](https://developer.apple.com/design/human-interface-guidelines/layout)

closed #5