### PR TITLE
비밀번호 리셋 TEST API 구현

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx lint-staged

--- a/src/app/api/store.ts
+++ b/src/app/api/store.ts
@@ -12,6 +12,10 @@ type UserVerification = {
   email: string;
   code: number;
 };
+// type passwordUpdate = {
+//   password: number;
+//   newPassword: number;
+// };
 
 class UserDB {
   db: User[] = [
@@ -63,6 +67,22 @@ class UserDB {
     }
     return false;
   }
+  passwordReset(newUser: UserEmail): number {
+    const { email } = newUser;
+    let result = -1;
+
+    for (const user of this.db) {
+      if (user.email == email) {
+        const randomPassword = Math.floor(Math.random() * 1000);
+        console.log(randomPassword);      
+        user.password = randomPassword + '';  
+        result = randomPassword;
+        return result;
+  
+      }
+    }
+      return result;
+  }
 
   emailVerification(newEmailVerify: UserVerification): boolean {
     const { email, code } = newEmailVerify;
@@ -74,6 +94,16 @@ class UserDB {
     }
     return false;
   }
+  // passwordUpdate(newEmailVerify: passwordUpdate): boolean {
+  //   const { password, newPassword } = newEmailVerify;
+  //   // console.log(email,code);
+  //   for (const user of this.vfdb) {
+  //     if (user.email == email && user.code == code) {
+  //       return true;
+  //     }
+  //   }
+  //   return false;
+  // }
 }
 
 export const userDB = new UserDB();

--- a/src/app/api/user/password/reset/route.ts
+++ b/src/app/api/user/password/reset/route.ts
@@ -1,21 +1,21 @@
-import { userDB } from "../store";
+import { userDB } from "@/app/api/store";
 
 export const POST = async (request: Request) => {
   try {
     const { email } = await request.json();
-    const result = userDB.emailExist({ email });
-    if (result == true) {
+    const result = userDB.passwordReset({ email });
+    if (result != -1) {
       return new Response(
-        JSON.stringify({ message: "이미 존재하는 이메일입니다. " }),
+        JSON.stringify({ message: "비밀번호 초기화 성공 " + result }),
         {
-          status: 401,
+          status: 201,
         }
       );
     }
     return new Response(
-      JSON.stringify({ message: "가입 가능한 이메일입니다." }),
+      JSON.stringify({ message: "이메일 존재 X " }),
       {
-        status: 201,
+        status: 401,
       }
     );
   } catch (error) {

--- a/src/app/api/user/password/update/route.ts
+++ b/src/app/api/user/password/update/route.ts
@@ -1,0 +1,18 @@
+import { userDB } from "@/app/api/store";
+
+export const POST = async (request: Request) => {
+  try {
+    const { password, newPassword } = await request.json();
+    const result = userDB.passwordUpdate({ password, newPassword });
+    if (result == true) {
+      return new Response(JSON.stringify({ message: "변경되었습니다. " }), {
+        status: 201,
+      });
+    }
+    return new Response(JSON.stringify({ message: "입력하신 비밀번호가 틀렸습니다." }), {
+      status: 401,
+    });
+  } catch (error) {
+    return new Response("Failed to create a new prompt", { status: 500 });
+  }
+};


### PR DESCRIPTION
이메일 존재 확인 후 비밀번호 초기화 하기 위한 랜덤 비밀번호 생성 후 출력까지 구현하였습니다.

### 메서드 구현
`src/app/api/store.ts`

```ts
 passwordReset(newUser: UserEmail): number {
    const { email } = newUser;
    let result = -1;

    for (const user of this.db) {
      if (user.email == email) {
        const randomPassword = Math.floor(Math.random() * 1000);
        console.log(randomPassword);      
        user.password = randomPassword + '';  
        result = randomPassword;
        return result;

      }
    }
      return result;
  }
```

- number를 리턴값으로 가지는 메서드를 작성하였습니다.  result를 -1로 초기화 해준 뒤 이메일 존재 여부를 확인한 후 랜덤한 값을 result 값으로 부여하도록 하였습니다. 여기서 이메일이 존재하지 않는다면 -1로서 false의 의미를 갖도록 하였습니다.

### RESET ROUTE
`src/app/api/user/password/reset/route.ts`
```ts
import { userDB } from "@/app/api/store";

export const POST = async (request: Request) => {
  try {
    const { email } = await request.json();
    const result = userDB.passwordReset({ email });
    if (result != -1) {
      return new Response(
        JSON.stringify({ message: "비밀번호 초기화 성공 " + result }),
        {
          status: 201,
        }
      );
    }
    return new Response(
      JSON.stringify({ message: "이메일 존재 X " }),
      {
        status: 401,
      }
    );
  } catch (error) {
    return new Response("Failed to create a new prompt", { status: 500 });
  }
};
```
- passwordReset 메서드를 통해 받아온 result값이 -1이 아니라면 status:201 과 함께 초기화 성공 메시지와 초기화 된 비밀번호를 확인할 수 있도록 하였습니다. 여기서 존재하지 않는 이메일이라면 status:401 상태코드와 함께 이메일 존재하지 않는다는 메시지를 확인할 수 있게 하였습니다.